### PR TITLE
Remove redundant public constructor modifier from not globally access…

### DIFF
--- a/src/main/java/org/orekit/data/ZipJarCrawler.java
+++ b/src/main/java/org/orekit/data/ZipJarCrawler.java
@@ -327,7 +327,7 @@ public class ZipJarCrawler implements DataProvider {
              * @param name name of the entry
              * @param isDirectory if true, the entry is a directory
              */
-            public EntryStream(final String name, final boolean isDirectory) {
+            EntryStream(final String name, final boolean isDirectory) {
                 this.name        = name;
                 this.isDirectory = isDirectory;
                 this.closed      = false;


### PR DESCRIPTION
…ible EntryStream in ZipJarCrawler